### PR TITLE
updated link in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Get Started
 
-Follow the steps in [Deployment Doc](https://docs.microsoft.com/en-us/office365/securitycompliance/archive-third-party-data-with-sample-connector) to get started.
+Follow the steps in [Deployment Doc](https://go.microsoft.com/fwlink/?linkid=2092569) to get started.
 
 
 # Disclaimer


### PR DESCRIPTION
Updated the "Deployment Doc" link to point to https://go.microsoft.com/fwlink/?linkid=2092569, which is the help doc to deploy Facebook sample connector; the old link is stale because the URL was changed.